### PR TITLE
API parameter expansion

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -5,12 +5,14 @@ const app = express();
 const port = process.env.PORT || 3500;
 var msdayhours = 1000*60*60*12;
 var last_day = Date.now() - msdayhours;
+var last_week = Date.now() - msdayhours*7;
 var iso_last_day = new Date(last_day).toISOString();
+var iso_last_week = new Date(last_week).toISOString();
 
 app.use(express.json());
 app.use(express.static(path.join(__dirname, '..','/public')));
 
-app.get('/api/AInews', async (req, res) => { 
+app.get('/api/AIgnews', async (req, res) => { 
     try {
        const params = new URLSearchParams({
         q: 'q = "AI OR \"artificial intelligence\" OR \"machine learning\"',
@@ -30,7 +32,7 @@ app.get('/api/AInews', async (req, res) => {
     }
 });
 
-app.get('/api/ManAIPharmanews', async (req, res) => { 
+app.get('/api/ManAIPharmagnews', async (req, res) => { 
     try {
        const params = new URLSearchParams({
         q: "(artificial intelligence OR AI) AND Manufacturing OR Pharmaceuticals", // OR has higher precedence so should work, ref docs 
@@ -49,7 +51,45 @@ app.get('/api/ManAIPharmanews', async (req, res) => {
         res.status(500).json({error: "There is an issue with AI Pharma News"})
     }
 });
+app.get('/api/WeekAIgnews', async (req, res) => { 
+    try {
+       const params = new URLSearchParams({
+        q: 'q = "AI OR \"artificial intelligence\" OR \"machine learning\"',
+        lang: 'en',
+        from: iso_last_week,
+        max: '10',
+        token: process.env.NEWS_API_KEY
+       })
+     
+    const response = await fetch(`https://gnews.io/api/v4/search?${params}`);
 
+    const data = await response.json();
+    res.json(data)}
+    
+    catch (err) { console.error(err);
+        res.status(500).json({error: "There is an issue with AI News"})
+    }
+});
+
+app.get('/api/WeekManAIPharmagnews', async (req, res) => { 
+    try {
+       const params = new URLSearchParams({
+        q: "(artificial intelligence OR AI) AND Manufacturing OR Pharmaceuticals", // OR has higher precedence so should work, ref docs 
+        lang: 'en',
+        from: iso_last_week,
+        max: '10',
+        token: process.env.NEWS_API_KEY
+       })
+     
+    const response = await fetch(`https://gnews.io/api/v4/search?${params}`);
+
+    const data = await response.json();
+    res.json(data)}
+    
+    catch (err) { console.error(err);
+        res.status(500).json({error: "There is an issue with AI Pharma News"})
+    }
+});
 app.get(/\/$|\/Mainpage(\.html)?/, (req,res) => {  // regex to handle variations of mainpage 
     res.sendFile(path.join(__dirname, '..', 'Mainpage.html'));
 });

--- a/public/mainscript.js
+++ b/public/mainscript.js
@@ -1,6 +1,7 @@
 function getManAI()
-{console.log("call Man AI");
-    fetch("/api/ManAIPharmanews")
+    {console.log("call Man AI");
+    getManAIWeek();
+    fetch("/api/ManAIPharmagnews")
     .then(res =>{             //adding error checking 
      console.log("status = ", res.status)
     return res.json();
@@ -15,7 +16,38 @@ function getManAI()
 
 function getAI() 
     {console.log("call AI");
-    fetch("/api/AInews")    
+    getAIweek();
+    fetch("/api/AIgnews")    
+    .then(res =>{             //adding error checking 
+     console.log("status = ", res.status)
+    return res.json();
+})
+    .then(data => { 
+         console.log(data);
+     })
+     .catch(err => {
+          console.error("fetch error:", err)
+     })
+    }
+
+function getAIweek() 
+    {console.log("call AI");
+    fetch("/api/WeekAIgnews")    
+    .then(res =>{             //adding error checking 
+     console.log("status = ", res.status)
+    return res.json();
+})
+    .then(data => { 
+         console.log(data);
+     })
+     .catch(err => {
+          console.error("fetch error:", err)
+     })
+    }
+
+function getManAIWeek()
+{console.log("call Man AI");
+    fetch("/api/WeekManAIPharmagnews")
     .then(res =>{             //adding error checking 
      console.log("status = ", res.status)
     return res.json();


### PR DESCRIPTION
Changed to iso-prev week to retrieve data. May need to add a date start to account for 0 articles on the last day.

If no response check same params using gnews interface on its dashboard. Might be a configuration issue.

Added a 'last week' api call for both Man AI and AI calls . 