### PR TITLE
Big rework of architecture

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -1,6 +1,7 @@
 // backend server JS file 
 //imports 
 const { standardiseGN, standardiseGuardian } = require("./utils/standardise")
+const { join_data } = require("./utils/join_data")
 const express = require('express');
 const path = require('path');
 
@@ -15,15 +16,18 @@ var iso_last_week = new Date(last_week).toISOString();
 var split_day = iso_last_day.split('T')[0];
 var split_week = iso_last_week.split('T')[0];
 
+//middleware
 app.use(express.json());
 app.use(express.static(path.join(__dirname, '..','/public')));
 
-app.get('/api/AIgnews', async (req, res) => { 
-    try {
-       const params = new URLSearchParams({
-        q: 'AI OR artificial intelligence OR machine learning',
+//get functions 
+
+
+async function fetchGN({q, from}) {
+    const params = new URLSearchParams({
+        q: q, // 'AI OR artificial intelligence OR machine learning',
         lang: 'en',
-        from: iso_last_day,
+        from: from, //iso_last_day,
         max: '10',
         token: process.env.NEWS_API_KEY
        })
@@ -31,169 +35,74 @@ app.get('/api/AIgnews', async (req, res) => {
     const response = await fetch(`https://gnews.io/api/v4/search?${params}`);
 
     const data = await response.json();     //read json to js object 
-    var standardised = data.articles.map(standardiseGN) //standardise output
-    res.json(standardised)} //respond with standardised json
-    
-    catch (err) { console.error(err);
-        res.status(500).json({error: "There is an issue with AI News"})
+    return data.articles 
     }
-});
 
-app.get('/api/ManAIPharmagnews', async (req, res) => { 
-    try {
-       const params = new URLSearchParams({
-        q: "(artificial intelligence OR AI) AND Manufacturing OR Pharmaceuticals", // OR has higher precedence so should work, ref docs 
-        lang: 'en',
-        from: iso_last_day,
-        max: '10',
-        token: process.env.NEWS_API_KEY
-       })
-     
-    const response = await fetch(`https://gnews.io/api/v4/search?${params}`);
-
-    const data = await response.json();
-    var standardised = data.articles.map(standardiseGN);
-    res.json(standardised)} 
-    
-    catch (err) { console.error(err);
-        res.status(500).json({error: "There is an issue with AI Pharma News"})
-    }
-});
-
-app.get('/api/WeekAIgnews', async (req, res) => { 
-    try {
-       const params = new URLSearchParams({
-        q: 'AI OR artificial intelligence OR machine learning',
-        lang: 'en',
-        from: iso_last_week,
-        max: '10',
-        token: process.env.NEWS_API_KEY
-       })
-     
-    const response = await fetch(`https://gnews.io/api/v4/search?${params}`);
-
-    const data = await response.json();
-    var standardised = data.articles.map(standardiseGN)
-    res.json(standardised)}
-    
-    catch (err) { console.error(err);
-        res.status(500).json({error: "There is an issue with AI News"})
-    }
-});
-
-app.get('/api/WeekManAIPharmagnews', async (req, res) => { 
-    try {
-       const params = new URLSearchParams({
-        q: "(artificial intelligence OR AI) AND Manufacturing OR Pharmaceuticals", // OR has higher precedence so should work, ref docs 
-        lang: 'en',
-        from: iso_last_week,
-        max: '10',
-        token: process.env.NEWS_API_KEY
-       })
-     
-    const response = await fetch(`https://gnews.io/api/v4/search?${params}`);
-
-    const data = await response.json();
-    var standardised = data.articles.map(standardiseGN)
-    res.json(standardised)}
-
-    catch (err) { console.error(err);
-        res.status(500).json({error: "There is an issue with AI Pharma News"})
-    }
-});
-
-// GUARDIAN APIS 
-app.get('/api/ManAIPharmaGuardian', async (req, res) => { 
-    try {
-       const params = new URLSearchParams({
-        q: '("artificial intelligence") AND (Manufacturing OR Pharmaceuticals)', 
+async function fetchGuardian({q, from}) {
+    const params = new URLSearchParams({
+        q: q, // , 
         'page-size':'50',
-        'from-date': split_day,
-        'show-fields':'headline',
-        'api-key': process.env.GUARDIAN_API_KEY,
-
-       })
-     
-    const response = await fetch(`https://content.guardianapis.com/search?${params}`);
-
-    const data = await response.json();
-    var rawOut  = data.response.results;
-    var standardised = rawOut.map(standardiseGuardian);// guardian works slightly different because of output format
-    res.json(standardised)}
-    
-    catch (err) { console.error(err);
-        res.status(500).json({error: "There is an issue with Guardian AI Pharma News"})
-    }
-});
-
-app.get('/api/AIGuardian', async (req, res) => { 
-    try {
-       const params = new URLSearchParams({
-        q: '"artificial intelligence" OR "machine learning"', 
-        'page-size':'50',
-        'from-date': split_day,
+        'from-date': from, // split_day,
         'show-fields':'headline',
         'api-key': process.env.GUARDIAN_API_KEY,
        })
      
     const response = await fetch(`https://content.guardianapis.com/search?${params}`);
-
     const data = await response.json();
-    var rawOut  = data.response.results;
-    var standardised = rawOut.map(standardiseGuardian);// guardian works slightly different because of output format
-    res.json(standardised)}
+    return data.response.results}
+
+
+app.get('/api/ManAI_Analysis', async (req, res) => { 
+    try{ 
+        //fetch 
+
+         const[rawGuardianDay, rawGNDay, rawGuardianWeek, rawGNWeek] = await Promise.all([
+            fetchGuardian({q:'("artificial intelligence") AND (Manufacturing OR Pharmaceuticals)', from: split_day}),
+            fetchGN({q:'"(artificial intelligence OR AI) AND Manufacturing OR Pharmaceuticals"', from:iso_last_day}),
+            fetchGuardian({q:'("artificial intelligence") AND (Manufacturing OR Pharmaceuticals)', from: split_wee}),
+            fetchGN({q:'"(artificial intelligence OR AI) AND Manufacturing OR Pharmaceuticals"', from:iso_last_week})        ])
+    
+        //standardise
+        var standardisedGuardianDay = rawGuardianDay.map(standardiseGuardian);
+        var standardisedGuardianWeek = rawGuardianWeek.map(standardiseGuardian);
+        var standardisedGNDay = rawGNDay.map(standardiseGN);
+        var standardisedGNWeek = rawGNWeek.map(standardiseGN);
+
+        //combine all
+        const combined = join_data({standardisedGuardianDay,standardisedGuardianWeek, standardisedGNDay, standardisedGNWeek}) 
+
+         res.json(combined)} 
     
     catch (err) { console.error(err);
-        res.status(500).json({error: "There is an issue with Guardian AI News"})
-    }
-});
+        res.status(500).json({error: "There is an issue with the server"})
+    }})
 
-app.get('/api/ManAIPharmaGuardianweek', async (req, res) => { 
-    try {
-       const params = new URLSearchParams({
-        q: '("artificial intelligence") AND (Manufacturing OR Pharmaceuticals)', 
-        'page-size':'50',
-        'from-date': split_week,
-        'show-fields':'headline',
-        'api-key': process.env.GUARDIAN_API_KEY,
 
-       })
-     
-    const response = await fetch(`https://content.guardianapis.com/search?${params}`);
+app.get('/api/AI_Analysis', async (req, res) => { 
+    try{ 
+        //fetch 
 
-    const data = await response.json();
-    var rawOut  = data.response.results;
-    var standardised = rawOut.map(standardiseGuardian);// guardian works slightly different because of output format
-    res.json(standardised)}
+         const[rawGuardianDay, rawGNDay, rawGuardianWeek, rawGNWeek] = await Promise.all([
+            fetchGuardian({q:'"artificial intelligence" OR "machine learning"', from: split_day}),
+            fetchGN({q:'AI OR artificial intelligence OR machine learning', from:iso_last_day}),
+            fetchGuardian({q:'"artificial intelligence" OR "machine learning"', from: split_week}),
+            fetchGN({q:'AI OR artificial intelligence OR machine learning', from:iso_last_week})        ])
+    
+        //standardise
+        var standardisedGuardianDay = rawGuardianDay.map(standardiseGuardian);
+        var standardisedGuardianWeek = rawGuardianWeek.map(standardiseGuardian);
+        var standardisedGNDay = rawGNDay.map(standardiseGN);
+        var standardisedGNWeek = rawGNWeek.map(standardiseGN);
+
+        //combine all
+        const combined = join_data({standardisedGuardianDay,standardisedGuardianWeek, standardisedGNDay, standardisedGNWeek}) 
+
+         res.json(combined)} 
     
     catch (err) { console.error(err);
-        res.status(500).json({error: "There is an issue with Guardian AI Pharma News"})
-    }
-});
-
-app.get('/api/AIGuardianWeek', async (req, res) => { 
-    try {
-       const params = new URLSearchParams({
-        q: '"artificial intelligence" OR "machine learning"', 
-        'page-size':'50',
-        'from-date': split_week,
-        'show-fields':'headline',
-        'api-key': process.env.GUARDIAN_API_KEY,
-       })
-     
-    const response = await fetch(`https://content.guardianapis.com/search?${params}`);
-
-    const data = await response.json();
-    var rawOut  = data.response.results;
-    var standardised = rawOut.map(standardiseGuardian);// guardian works slightly different because of output format
-    res.json(standardised)}
-    
-    catch (err) { console.error(err);
-        res.status(500).json({error: "There is an issue with Guardian AI News"})
-    }
-});
-
-
+        res.status(500).json({error: "There is an issue with the server"})
+    }})
+    //routing 
 app.get(/\/$|\/Mainpage(\.html)?/, (req,res) => {  // regex to handle variations of mainpage 
     res.sendFile(path.join(__dirname, '..', 'Mainpage.html'));
 });

--- a/backend/utils/join_data.js
+++ b/backend/utils/join_data.js
@@ -1,0 +1,10 @@
+function join_data( { guardianday = [], guardianweek = [], gnewsday = [], gnewsweek = []}){
+    return [
+        ...guardianday,
+        ...guardianweek,
+        ...gnewsday, 
+        ...gnewsweek
+    ]
+}
+
+module.exports = { join_data }

--- a/backend/utils/standardise.js
+++ b/backend/utils/standardise.js
@@ -5,7 +5,7 @@ const spaces = /\s+/g
 function standardiseGN(data){
     return{
         title: standardiseTitle(data.title),
-        publishedAt: data.publishedAt,
+        publishedAt: data.publishedAt.split("T")[0],
         tokens: stripTokens(tokenizeTitles(standardiseTitle(data.title)))
     };
 }

--- a/public/mainscript.js
+++ b/public/mainscript.js
@@ -1,141 +1,30 @@
-//DAILY CALLS 
-//gnews
-function getManAI_GN()
-    {;
-    fetch("/api/ManAIPharmagnews")
-    .then(res =>{             //adding error checking 
-     console.log("status = ", res.status)
-    return res.json();
-})
-    .then(data => { 
-         console.log(data);
-     })
-     .catch(err => {
-          console.error("fetch error:", err)
-     })
-    }
-
-function getAI_GN() 
-    {
-    fetch("/api/AIgnews")    
-    .then(res =>{             //adding error checking 
-     console.log("status = ", res.status)
-    return res.json();
-})
-    .then(data => { 
-         console.log(data);
-     })
-     .catch(err => {
-          console.error("fetch error:", err)
-     })
-    }
-//guardian 
-function getAI_Guardian(){
-    {
-        fetch("/api/AIGuardian")
-    .then(res =>{             //adding error checking 
-     console.log("status = ", res.status)
-    return res.json();
-})
-    .then(data => { 
-         console.log(data);
-     })
-     .catch(err => {
-          console.error("fetch error:", err)
-     })
-    }
-}
-
-function getManAI_Guardian(){
-    {
-        fetch("/api/ManAIPharmaGuardian")
-    .then(res =>{             //adding error checking 
-     console.log("status = ", res.status)
-    return res.json();
-})
-    .then(data => { 
-         console.log(data);
-     })
-     .catch(err => {
-          console.error("fetch error:", err)
-     })
-    }
-}
-//WEEKLY CALLS
-//gnews
-function getAIweek_GN() 
-    {
-    fetch("/api/WeekAIgnews")    
-    .then(res =>{             //adding error checking 
-     console.log("status = ", res.status)
-    return res.json();
-})
-    .then(data => { 
-         console.log(data);
-     })
-     .catch(err => {
-          console.error("fetch error:", err)
-     })
-    }
-
-function getManAIWeek_GN()
-{
-    fetch("/api/WeekManAIPharmagnews")
-    .then(res =>{             //adding error checking 
-     console.log("status = ", res.status)
-    return res.json();
-})
-    .then(data => { 
-         console.log(data);
-     })
-     .catch(err => {
-          console.error("fetch error:", err)
-     })
-    }
-
-//GUARDIAN 
-
-function getAI_GuardianWeek(){
-    {
-        fetch("/api/AIGuardianWeek")
-    .then(res =>{             //adding error checking 
-     console.log("status = ", res.status)
-    return res.json();
-})
-    .then(data => { 
-         console.log(data);
-     })
-     .catch(err => {
-          console.error("fetch error:", err)
-     })
-    }
-}
-
-function getManAI_GuardianWeek(){
-    {   fetch("/api/ManAIPharmaGuardianweek")
-    .then(res =>{             //adding error checking 
-     console.log("status = ", res.status)
-    return res.json();
-})
-    .then(data => { 
-         console.log(data);
-     })
-     .catch(err => {
-          console.error("fetch error:", err)
-     })
-    }
-}
+const { get } = require("node:http");
 
 function getAI(){
-    getAI_GN();
-    getAIweek_GN();
-    getAI_Guardian();
-    getAI_GuardianWeek();
-};
+      {fetch("/api/AI_Analysis")
+        .then(res => res.json())
+        .then(data => {
+            //draw paretos
+            //draw radars
+            //make text cards 
+
+            console.log(data)
+        })  
+        .catch(err => {
+          console.error("fetch error:", err)
+     })}}
+
 
 function getManAI(){
-    getManAI_GN();
-    getManAIWeek_GN();
-    getManAI_Guardian();
-    getManAI_GuardianWeek();
-}
+      {fetch("/api/ManAI_Analysis")
+        .then(res => res.json())
+        .then(data => {
+            //draw paretos
+            //draw radars
+            //make text cards 
+
+            console.log(data)
+        })  
+        .catch(err => {
+          console.error("fetch error:", err)
+     })}}


### PR DESCRIPTION
# Join_script.js

map to join the api standardised outputs ready for analysis
returns to server.js

# mainscript.js

removed all individual api calls and consolidated to one get_anlysis call for each type of analysis (one per button) 
much cleaner to look at 
ready for chart render functions once analysis is applied

# server.js

Most change 
consolidated all my fetch endpoints into new get functions, using q and from as parameters (the only things that were changing between api's for each of the 4 queries per endpoint 

Setup just two endpoints; get_Ai and get_manAI analysis 
thee call the fetch functions and control each stage of the processing, i.e. standrdising, joining and analysing 

# standardise.js

added a small .split("t")[0] to make gnews output the same as the guardian ones
did not want to add a source column, no functional value to the user 



