### PR TITLE
Removed ai token which is now on the extra/stop words list

### DIFF
--- a/backend/tests/standardiseGuardian.test.js
+++ b/backend/tests/standardiseGuardian.test.js
@@ -9,7 +9,7 @@ test("standardises guardian article data correctly", () => {
     expect(standardiseGuardian(article)).toEqual({
         title: "ai news",
         publishedAt: "2026-01-12T10:00:00Z",
-        tokens: ["ai", "news"]
+        tokens: [ "news"]
 
     });
 });


### PR DESCRIPTION
Removed an extra 'ai' token that now is on the stopwords list. error tested with npm and woking fine 